### PR TITLE
Clean up unused deps and dead refs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,11 +19,9 @@ yarn lint
 ### Primary files
 
 - `src/calculator-card.ts` — main card implementation
-- `src/editor.ts` — visual editor (`LovelaceCardEditor`)
+- `src/editor.ts` — visual editor config form
 - `src/types.ts` — card config and type definitions
-- `src/action-handler-directive.ts` — tap/hold/double-tap directive
-- `src/localize/localize.ts` — localization helper
-- `src/localize/languages/en.json` and `src/localize/languages/nb.json` — translation files
+- `src/consts.ts` — constants
 - `rollup.config.js` and `rollup.config.dev.js` — production and dev build config
 
 ## Architecture and patterns
@@ -52,16 +50,13 @@ yarn lint
 ## Home Assistant integration
 
 - Use Home Assistant helpers and conventions from `custom-card-helpers`.
-- Ensure tap, hold, and double-tap actions are wired through existing action patterns.
 - Support unavailable/loading/error states gracefully.
 - Keep Lovelace config compatibility in mind when changing schema or defaults.
 
-## Localization and copy
+## Copy
 
-- Do not hardcode user-facing strings when a localize key should be used.
-- Add new translation keys to both language files currently in the repo (`en.json`, `nb.json`).
 - Keep copy concise, sentence case, and user-facing.
-- Favor consistent terminology across card UI and editor labels.
+- Favour consistent terminology across card UI and editor labels.
 
 ## Styling and UX
 
@@ -96,6 +91,6 @@ yarn lint
 
 - Breaking editor/card config parity
 - Adding untyped dynamic config access
-- Hardcoding text instead of localization keys
+- Hardcoding text that should be configurable
 - Overriding theme behavior with fixed styles
 - Changing output filenames or card tag without explicit request

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "A custom Home Assistant dashboard card",
   "main": "dist/calculator-card.js",
-  "module": "boilerplate-card.js",
+  "module": "dist/calculator-card.js",
   "scripts": {
     "start": "rollup -c rollup.config.dev.js --watch",
     "build": "yarn clean && yarn lint && yarn rollup",
@@ -22,12 +22,7 @@
   "repository": "git@github.com:schafran/calculator-card.git",
   "license": "MIT",
   "dependencies": {
-    "@lit-labs/context": "0.4.1",
-    "@lit-labs/motion": "1.0.7",
-    "@lit-labs/observers": "2.0.2",
-    "@lit-labs/virtualizer": "2.0.12",
     "custom-card-helpers": "2.0.0",
-    "home-assistant-js-websocket": "9.6.0",
     "lit": "^3.3.2"
   },
   "devDependencies": {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,1 @@
 export const CARD_NAME = 'calculator-card';
-export const CARD_VERSION = '0.1.0';
-export const CARD_EDITOR_NAME = `${CARD_NAME}-editor`;


### PR DESCRIPTION
## Summary

- Remove unused deps (@lit-labs/*, home-assistant-js-websocket)
- Fix module field (was boilerplate-card.js)
- Remove duplicate CARD_VERSION and unused CARD_EDITOR_NAME
- Update copilot-instructions.md to reflect actual files

## Test plan

- [x] `yarn lint` passes
- [x] `yarn build` passes