### PR TITLE
Styling cleanup, precision fix, Lit decorator fix

### DIFF
--- a/src/calculator-card.ts
+++ b/src/calculator-card.ts
@@ -59,6 +59,11 @@ export class CalculatorCard extends LitElement {
     }
   }
 
+  private formatResult(result: number): string {
+    if (!Number.isFinite(result)) return 'Error';
+    return String(parseFloat(result.toPrecision(12)));
+  }
+
   private handleOperatorClick(nextOperator: string): void {
     const inputValue = parseFloat(this.display);
 
@@ -66,7 +71,7 @@ export class CalculatorCard extends LitElement {
       this.firstOperand = inputValue;
     } else if (this.operator) {
       const result = this.calculate(this.firstOperand, inputValue, this.operator);
-      this.display = String(result);
+      this.display = this.formatResult(result);
       this.firstOperand = result;
     }
 
@@ -83,7 +88,7 @@ export class CalculatorCard extends LitElement {
       case '×':
         return firstOperand * secondOperand;
       case '÷':
-        return secondOperand !== 0 ? firstOperand / secondOperand : 0;
+        return firstOperand / secondOperand;
       default:
         return secondOperand;
     }
@@ -93,7 +98,7 @@ export class CalculatorCard extends LitElement {
     if (this.operator && this.firstOperand !== null) {
       const inputValue = parseFloat(this.display);
       const result = this.calculate(this.firstOperand, inputValue, this.operator);
-      this.display = String(result);
+      this.display = this.formatResult(result);
       this.firstOperand = null;
       this.operator = null;
       this.waitingForOperand = true;
@@ -154,79 +159,73 @@ export class CalculatorCard extends LitElement {
     `;
   }
 
-  static get styles() {
-    return css`
-      :host {
-        display: block;
-      }
-      .card-content {
-        padding: 16px;
-      }
-      .calculator {
-        max-width: 300px;
-        margin: 0 auto;
-      }
-      .display {
-        background-color: var(--primary-background-color);
-        color: var(--primary-text-color);
-        font-size: 32px;
-        font-weight: bold;
-        text-align: right;
-        padding: 20px;
-        margin-bottom: 10px;
-        border-radius: 8px;
-        border: 2px solid var(--divider-color);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-      .buttons {
-        display: grid;
-        grid-template-columns: repeat(4, 1fr);
-        gap: 8px;
-      }
-      .btn {
-        background-color: var(--card-background-color);
-        color: var(--primary-text-color);
-        border: 2px solid var(--divider-color);
-        border-radius: 8px;
-        font-size: 20px;
-        padding: 20px;
-        cursor: pointer;
-        transition: all 0.2s;
-      }
-      .btn:hover {
-        background-color: var(--secondary-background-color);
-        transform: scale(1.05);
-      }
-      .btn:active {
-        transform: scale(0.95);
-      }
-      .btn-operator {
-        background-color: var(--primary-color);
-        color: var(--text-primary-color);
-      }
-      .btn-operator:hover {
-        background-color: var(--dark-primary-color);
-      }
-      .btn-clear {
-        background-color: var(--error-color);
-        color: var(--text-primary-color);
-        grid-column: span 3;
-      }
-      .btn-clear:hover {
-        background-color: var(--error-state-color);
-      }
-      .btn-equals {
-        background-color: var(--success-color);
-        color: var(--text-primary-color);
-      }
-      .btn-equals:hover {
-        background-color: var(--success-state-color);
-      }
-      .btn-zero {
-        grid-column: span 2;
-      }
-    `;
-  }
+  static styles = css`
+    :host {
+      --calc-btn-radius: var(--ha-card-border-radius, 8px);
+      --calc-spacing: 8px;
+      --calc-btn-padding: 20px;
+      display: block;
+    }
+    .card-content {
+      padding: var(--calc-spacing) calc(var(--calc-spacing) * 2);
+    }
+    .calculator {
+      max-width: 300px;
+      margin: 0 auto;
+    }
+    .display {
+      background-color: var(--primary-background-color);
+      color: var(--primary-text-color);
+      font-size: 2rem;
+      font-weight: bold;
+      text-align: right;
+      padding: var(--calc-btn-padding);
+      margin-bottom: var(--calc-spacing);
+      border-radius: var(--calc-btn-radius);
+      border: 1px solid var(--divider-color);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .buttons {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: var(--calc-spacing);
+    }
+    .btn {
+      background-color: var(--card-background-color);
+      color: var(--primary-text-color);
+      border: 1px solid var(--divider-color);
+      border-radius: var(--calc-btn-radius);
+      font-size: 1.25rem;
+      padding: var(--calc-btn-padding);
+      cursor: pointer;
+      transition:
+        filter 0.15s ease,
+        transform 0.1s ease;
+    }
+    .btn:hover {
+      filter: brightness(0.9);
+      transform: scale(1.05);
+    }
+    .btn:active {
+      transform: scale(0.95);
+    }
+    .btn-operator {
+      background-color: var(--primary-color);
+      color: var(--text-primary-color);
+    }
+    .btn-clear {
+      background-color: var(--error-color);
+      color: var(--text-primary-color);
+      grid-column: span 3;
+    }
+    .btn-equals {
+      background-color: var(--success-color);
+      color: var(--text-primary-color);
+    }
+    .btn-zero {
+      grid-column: span 2;
+    }
+  `;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,54 +318,17 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lit-labs/context@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/@lit-labs/context/-/context-0.4.1.tgz"
-  integrity sha512-o+uKepgEPoYAVaPvSASoDiUWKdcf7neyhFcm9dvtiLgptKoINZD1vW7GbbH/2hPtxLxgcmVfZ9NDCXNDQeHTHQ==
-  dependencies:
-    "@lit/reactive-element" "^1.5.0"
-    lit "^2.7.0"
-
-"@lit-labs/motion@1.0.7":
-  version "1.0.7"
-  resolved "https://registry.npmjs.org/@lit-labs/motion/-/motion-1.0.7.tgz"
-  integrity sha512-odykI6Talw274lYRWQvrGNplHzRy5QAtYEMbqonX6oesEuDQq1nR9Mis38X587jinj68Gjria0mlzqowJ1FACw==
-  dependencies:
-    lit "^3.1.2"
-
-"@lit-labs/observers@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/@lit-labs/observers/-/observers-2.0.2.tgz"
-  integrity sha512-eZb5+W9Cb0e/Y5m1DNxBSGTvGB2TAVTGMnTxL/IzFhPQEcZIAHewW1eVBhN8W07A5tirRaAmmF6fGL1V20p3gQ==
-  dependencies:
-    "@lit/reactive-element" "^1.0.0 || ^2.0.0"
-
-"@lit-labs/ssr-dom-shim@^1.0.0", "@lit-labs/ssr-dom-shim@^1.1.0", "@lit-labs/ssr-dom-shim@^1.5.0":
+"@lit-labs/ssr-dom-shim@^1.5.0":
   version "1.5.1"
   resolved "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz"
   integrity sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==
 
-"@lit-labs/virtualizer@2.0.12":
-  version "2.0.12"
-  resolved "https://registry.npmjs.org/@lit-labs/virtualizer/-/virtualizer-2.0.12.tgz"
-  integrity sha512-sL7AXhacSdzOJLEQFcPCrV7tu2rZQ10upeGMAxKmTT0Ae4kBFV8nwlFiUEQPBt1idUsAkiDG1yN91IgUWQXVNQ==
-  dependencies:
-    lit "^3.1.0"
-    tslib "^2.0.3"
-
-"@lit/reactive-element@^1.0.0 || ^2.0.0", "@lit/reactive-element@^2.1.0":
+"@lit/reactive-element@^2.1.0":
   version "2.1.2"
   resolved "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz"
   integrity sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==
   dependencies:
     "@lit-labs/ssr-dom-shim" "^1.5.0"
-
-"@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.5.0", "@lit/reactive-element@^1.6.0":
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz"
-  integrity sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==
-  dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.0.0"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -1563,7 +1526,7 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-home-assistant-js-websocket@9.6.0, home-assistant-js-websocket@^9.6.0:
+home-assistant-js-websocket@^9.6.0:
   version "9.6.0"
   resolved "https://registry.npmjs.org/home-assistant-js-websocket/-/home-assistant-js-websocket-9.6.0.tgz"
   integrity sha512-TK8HWW6UjCsUdjIBQRB2sBbEya0VniOBFqFjgqSznJiB7YriNgN8jghyThxOkgxwrnt2eN6oWoZMCTSp1o7H+w==
@@ -1868,15 +1831,6 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-lit-element@^3.3.0:
-  version "3.3.3"
-  resolved "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz"
-  integrity sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==
-  dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.1.0"
-    "@lit/reactive-element" "^1.3.0"
-    lit-html "^2.8.0"
-
 lit-element@^4.2.0:
   version "4.2.2"
   resolved "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz"
@@ -1886,13 +1840,6 @@ lit-element@^4.2.0:
     "@lit/reactive-element" "^2.1.0"
     lit-html "^3.3.0"
 
-lit-html@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz"
-  integrity sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==
-  dependencies:
-    "@types/trusted-types" "^2.0.2"
-
 lit-html@^3.3.0:
   version "3.3.2"
   resolved "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz"
@@ -1900,16 +1847,7 @@ lit-html@^3.3.0:
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit@^2.7.0:
-  version "2.8.0"
-  resolved "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz"
-  integrity sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==
-  dependencies:
-    "@lit/reactive-element" "^1.6.0"
-    lit-element "^3.3.0"
-    lit-html "^2.8.0"
-
-lit@^3.1.0, lit@^3.1.2, lit@^3.3.2:
+lit@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz"
   integrity sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==
@@ -2578,7 +2516,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.3, tslib@^2.6.0, tslib@^2.8.1:
+tslib@^2.6.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## Summary

- Use HA theme vars consistently, unified hover with `filter: brightness(0.9)`
- Add `formatResult()` with `toPrecision(12)` for clean float display (fixes 0.1+0.2 bug)
- Division by zero now shows "Error" instead of 0
- Add `useDefineForClassFields: false` to tsconfig - required for Lit `@state()` reactivity

## Test plan

- [x] `yarn lint` passes
- [x] `yarn build` passes
- [ ] Test calculator operations in HA
- [ ] Verify 0.1 + 0.2 = 0.3 (not 0.30000000000000004)
- [ ] Verify division by zero shows "Error"