### PR TITLE
Add function buttons and colour customisation

### DIFF
--- a/src/calculator-card.ts
+++ b/src/calculator-card.ts
@@ -6,6 +6,88 @@ import { CalculatorCardConfig } from './types';
 import { CARD_NAME } from './consts';
 import { getConfigForm } from './editor';
 
+const THEME_COLORS = new Set([
+  'primary',
+  'accent',
+  'red',
+  'pink',
+  'purple',
+  'deep-purple',
+  'indigo',
+  'blue',
+  'light-blue',
+  'cyan',
+  'teal',
+  'green',
+  'light-green',
+  'lime',
+  'yellow',
+  'amber',
+  'orange',
+  'deep-orange',
+  'brown',
+  'light-grey',
+  'grey',
+  'dark-grey',
+  'blue-grey',
+  'black',
+  'white',
+]);
+
+// Theme colours that need white/light text (dark backgrounds)
+const DARK_BG_COLORS = new Set([
+  'primary',
+  'accent',
+  'red',
+  'pink',
+  'purple',
+  'deep-purple',
+  'indigo',
+  'blue',
+  'teal',
+  'green',
+  'brown',
+  'blue-grey',
+  'dark-grey',
+  'black',
+]);
+
+function computeCssColor(color: string): string {
+  if (THEME_COLORS.has(color)) {
+    return `var(--${color}-color)`;
+  }
+  return color;
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!result) return null;
+  return {
+    r: parseInt(result[1], 16),
+    g: parseInt(result[2], 16),
+    b: parseInt(result[3], 16),
+  };
+}
+
+function getContrastTextColor(bgColor: string): string {
+  if (DARK_BG_COLORS.has(bgColor)) {
+    return 'var(--text-primary-color)';
+  }
+  if (THEME_COLORS.has(bgColor)) {
+    // Light theme colours get dark text
+    return 'var(--primary-text-color)';
+  }
+  if (bgColor.startsWith('#')) {
+    const rgb = hexToRgb(bgColor);
+    if (rgb) {
+      // Calculate relative luminance
+      const luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
+      return luminance > 0.5 ? 'var(--primary-text-color)' : 'var(--text-primary-color)';
+    }
+  }
+  return 'inherit';
+}
+
 console.info(
   `%c ${CARD_NAME.toUpperCase()} %c ${packageJson.version}`,
   'color: orange; font-weight: bold; background: black',
@@ -152,14 +234,25 @@ export class CalculatorCard extends LitElement {
       return html``;
     }
 
+    const styles = [
+      this.config.color_numeral ? `--calc-color-numeral: ${computeCssColor(this.config.color_numeral)}` : '',
+      this.config.color_numeral ? `--calc-text-numeral: ${getContrastTextColor(this.config.color_numeral)}` : '',
+      this.config.color_function ? `--calc-color-function: ${computeCssColor(this.config.color_function)}` : '',
+      this.config.color_function ? `--calc-text-function: ${getContrastTextColor(this.config.color_function)}` : '',
+      this.config.color_operator ? `--calc-color-operator: ${computeCssColor(this.config.color_operator)}` : '',
+      this.config.color_operator ? `--calc-text-operator: ${getContrastTextColor(this.config.color_operator)}` : '',
+    ]
+      .filter(Boolean)
+      .join('; ');
+
     return html`
-      <ha-card .header=${this.config.title}>
+      <ha-card .header=${this.config.title} style=${styles ? styles + ';' : ''}>
         <div class="card-content">
           <div class="calculator">
             <div class="display">${this.display}</div>
             <div class="buttons">
-              <button class="btn btn-clear" @click=${this.handleClear}>AC</button>
               <button class="btn btn-function" @click=${this.handleBackspace}>⌫</button>
+              <button class="btn btn-function" @click=${this.handleClear}>AC</button>
               <button class="btn btn-function" @click=${this.handlePercentage}>%</button>
               <button class="btn btn-operator" @click=${() => this.handleOperatorClick('÷')}>÷</button>
 
@@ -178,10 +271,10 @@ export class CalculatorCard extends LitElement {
               <button class="btn" @click=${() => this.handleNumberClick('3')}>3</button>
               <button class="btn btn-operator" @click=${() => this.handleOperatorClick('+')}>+</button>
 
-              <button class="btn btn-function" @click=${this.handleSignToggle}>+/−</button>
+              <button class="btn" @click=${this.handleSignToggle}>+/−</button>
               <button class="btn" @click=${() => this.handleNumberClick('0')}>0</button>
               <button class="btn" @click=${this.handleDecimal}>.</button>
-              <button class="btn btn-equals" @click=${this.handleEquals}>=</button>
+              <button class="btn btn-operator" @click=${this.handleEquals}>=</button>
             </div>
           </div>
         </div>
@@ -223,8 +316,8 @@ export class CalculatorCard extends LitElement {
       gap: var(--calc-spacing);
     }
     .btn {
-      background-color: var(--card-background-color);
-      color: var(--primary-text-color);
+      background-color: var(--calc-color-numeral, var(--card-background-color));
+      color: var(--calc-text-numeral, var(--primary-text-color));
       border: 1px solid var(--divider-color);
       border-radius: var(--calc-btn-radius);
       font-size: 1.25rem;
@@ -241,21 +334,13 @@ export class CalculatorCard extends LitElement {
     .btn:active {
       transform: scale(0.95);
     }
-    .btn-operator {
-      background-color: var(--primary-color);
-      color: var(--text-primary-color);
-    }
-    .btn-clear {
-      background-color: var(--error-color);
-      color: var(--text-primary-color);
-    }
     .btn-function {
-      background-color: var(--secondary-background-color);
-      color: var(--primary-text-color);
+      background-color: var(--calc-color-function, var(--secondary-background-color));
+      color: var(--calc-text-function, var(--primary-text-color));
     }
-    .btn-equals {
-      background-color: var(--success-color);
-      color: var(--text-primary-color);
+    .btn-operator {
+      background-color: var(--calc-color-operator, var(--primary-color));
+      color: var(--calc-text-operator, var(--text-primary-color));
     }
   `;
 }

--- a/src/calculator-card.ts
+++ b/src/calculator-card.ts
@@ -112,6 +112,32 @@ export class CalculatorCard extends LitElement {
     this.waitingForOperand = false;
   }
 
+  private handleBackspace(): void {
+    if (this.display === '0' || this.display === 'Error' || this.waitingForOperand) {
+      return;
+    }
+    if (this.display.length === 1 || (this.display.length === 2 && this.display.startsWith('-'))) {
+      this.display = '0';
+    } else {
+      this.display = this.display.slice(0, -1);
+    }
+  }
+
+  private handlePercentage(): void {
+    const value = parseFloat(this.display);
+    if (!Number.isFinite(value)) return;
+    this.display = this.formatResult(value / 100);
+  }
+
+  private handleSignToggle(): void {
+    if (this.display === '0' || this.display === 'Error') return;
+    if (this.display.startsWith('-')) {
+      this.display = this.display.slice(1);
+    } else {
+      this.display = '-' + this.display;
+    }
+  }
+
   private handleDecimal(): void {
     if (this.waitingForOperand) {
       this.display = '0.';
@@ -132,7 +158,9 @@ export class CalculatorCard extends LitElement {
           <div class="calculator">
             <div class="display">${this.display}</div>
             <div class="buttons">
-              <button class="btn btn-clear" @click=${this.handleClear}>C</button>
+              <button class="btn btn-clear" @click=${this.handleClear}>AC</button>
+              <button class="btn btn-function" @click=${this.handleBackspace}>⌫</button>
+              <button class="btn btn-function" @click=${this.handlePercentage}>%</button>
               <button class="btn btn-operator" @click=${() => this.handleOperatorClick('÷')}>÷</button>
 
               <button class="btn" @click=${() => this.handleNumberClick('7')}>7</button>
@@ -144,12 +172,14 @@ export class CalculatorCard extends LitElement {
               <button class="btn" @click=${() => this.handleNumberClick('5')}>5</button>
               <button class="btn" @click=${() => this.handleNumberClick('6')}>6</button>
               <button class="btn btn-operator" @click=${() => this.handleOperatorClick('-')}>−</button>
+
               <button class="btn" @click=${() => this.handleNumberClick('1')}>1</button>
               <button class="btn" @click=${() => this.handleNumberClick('2')}>2</button>
               <button class="btn" @click=${() => this.handleNumberClick('3')}>3</button>
               <button class="btn btn-operator" @click=${() => this.handleOperatorClick('+')}>+</button>
 
-              <button class="btn btn-zero" @click=${() => this.handleNumberClick('0')}>0</button>
+              <button class="btn btn-function" @click=${this.handleSignToggle}>+/−</button>
+              <button class="btn" @click=${() => this.handleNumberClick('0')}>0</button>
               <button class="btn" @click=${this.handleDecimal}>.</button>
               <button class="btn btn-equals" @click=${this.handleEquals}>=</button>
             </div>
@@ -218,14 +248,14 @@ export class CalculatorCard extends LitElement {
     .btn-clear {
       background-color: var(--error-color);
       color: var(--text-primary-color);
-      grid-column: span 3;
+    }
+    .btn-function {
+      background-color: var(--secondary-background-color);
+      color: var(--primary-text-color);
     }
     .btn-equals {
       background-color: var(--success-color);
       color: var(--text-primary-color);
-    }
-    .btn-zero {
-      grid-column: span 2;
     }
   `;
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -3,6 +3,18 @@ export const configSchema = [
     name: 'title',
     selector: { text: {} },
   },
+  {
+    name: 'color_numeral',
+    selector: { ui_color: {} },
+  },
+  {
+    name: 'color_function',
+    selector: { ui_color: {} },
+  },
+  {
+    name: 'color_operator',
+    selector: { ui_color: {} },
+  },
 ];
 
 export const getConfigForm = () => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,4 +2,7 @@ import { LovelaceCardConfig } from 'custom-card-helpers';
 
 export interface CalculatorCardConfig extends LovelaceCardConfig {
   title?: string;
+  color_numeral?: string;
+  color_function?: string;
+  color_operator?: string;
 }


### PR DESCRIPTION
## Summary
- Add backspace (⌫), percentage (%), and sign toggle (+/−) buttons
- Add colour pickers for numeral, function, and operator buttons
- Auto-compute contrasting text colour based on background luminance

## Test plan
- [x] Verify new buttons work correctly
- [x] Test colour customisation in editor
- [x] Confirm text is legible on dark/light backgrounds